### PR TITLE
스웨거 전역 auth 헤더 세팅 추가

### DIFF
--- a/src/main/java/com/workat/common/config/SwaggerConfig.java
+++ b/src/main/java/com/workat/common/config/SwaggerConfig.java
@@ -1,5 +1,8 @@
 package com.workat.common.config;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
@@ -11,10 +14,13 @@ import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
 
 @Configuration
 @EnableSwagger2
@@ -24,12 +30,13 @@ public class SwaggerConfig {
 
 	private static final String API_VERSION = "1.0";
 
-
 	@Bean
 	public Docket api() {
 		return new Docket(DocumentationType.SWAGGER_2)
 			.ignoredParameterTypes(Users.class)
 			.apiInfo(getApiInfo())
+			.securitySchemes(Arrays.asList(apiKey()))
+			.securityContexts(Arrays.asList(securityContext()))
 			.produces(Sets.newHashSet(MediaType.APPLICATION_JSON_VALUE))
 			.consumes(Sets.newHashSet(MediaType.APPLICATION_JSON_VALUE))
 			.select()
@@ -45,4 +52,24 @@ public class SwaggerConfig {
 			.build();
 	}
 
+	private ApiKey apiKey() {
+		return new ApiKey("JWT", "Authorization", "header");
+	}
+
+	private SecurityContext securityContext() {
+		return springfox
+			.documentation
+			.spi.service
+			.contexts
+			.SecurityContext
+			.builder()
+			.securityReferences(defaultAuth()).forPaths(PathSelectors.any()).build();
+	}
+
+	List<SecurityReference> defaultAuth() {
+		AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+		AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+		authorizationScopes[0] = authorizationScope;
+		return Arrays.asList(new SecurityReference("JWT", authorizationScopes));
+	}
 }


### PR DESCRIPTION
#### AS-IS
인증 헤더가 필요한 api의 경우 스웨거에서 테스트가 어려웠음

#### TO-BE
스웨거에서 헤더 붙일 수 있도록 수정

<img width="700" alt="image" src="https://user-images.githubusercontent.com/46865281/180599599-54cfef0d-1de0-43a5-a579-533ba7a78f90.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/46865281/180599564-980af887-457e-413a-b7fe-d45786d6dc49.png">

#### 리뷰시 중점 사항

#### 참조사항
