### PR TITLE
feat: 메일 인증 api 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'commons-io:commons-io:2.11.0'
     implementation 'commons-fileupload:commons-fileupload:1.4'
+    implementation 'org.springframework.boot:spring-boot-starter-mail:2.7.0'
 
     //Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/workat/api/user/controller/UserController.java
+++ b/src/main/java/com/workat/api/user/controller/UserController.java
@@ -89,8 +89,7 @@ public class UserController {
 		// TODO: 메일 인증 후 redirect 페이지 여부에 따라 변경 가능
 		if (userService.verify(code)) {
 			return "verify_success";
-		} else {
-			return "verify_fail";
 		}
+		return "verify_fail";
 	}
 }

--- a/src/main/java/com/workat/api/user/controller/UserController.java
+++ b/src/main/java/com/workat/api/user/controller/UserController.java
@@ -1,7 +1,12 @@
 package com.workat.api.user.controller;
 
+import java.io.UnsupportedEncodingException;
+
+import javax.mail.MessagingException;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.workat.api.user.dto.SignUpResponse;
+import com.workat.api.user.dto.request.EmailCertifyRequest;
 import com.workat.api.user.dto.request.SignUpRequest;
 import com.workat.api.user.dto.request.UserUpdateRequest;
 import com.workat.api.user.dto.response.MyProfileResponse;
@@ -23,6 +29,7 @@ import com.workat.domain.user.entity.Users;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import springfox.documentation.annotations.ApiIgnore;
 
 @Api(tags = "User Api")
 @RequiredArgsConstructor
@@ -63,5 +70,26 @@ public class UserController {
 	public String uploadProfileImage(@UserValidation Users user, @RequestParam("file") MultipartFile multipartFile) {
 		String redirectURI = userService.uploadProfileImage(user.getId(), multipartFile);
 		return "redirect:" + redirectURI;
+	}
+
+	@PostMapping("/api/v1/user/verify")
+	public ResponseEntity<?> sendCompanyVerifyEmail(@UserValidation Users user, @Valid @RequestBody EmailCertifyRequest emailCertifyRequest, HttpServletRequest request) throws UnsupportedEncodingException, MessagingException {
+		userService.sendCompanyVerifyEmail(user.getId(), emailCertifyRequest, getSiteURL(request));
+		return ResponseEntity.ok().build();
+	}
+
+	private String getSiteURL(HttpServletRequest request) {
+		String siteURL = request.getRequestURL().toString();
+		return siteURL.replace(request.getServletPath(), "");
+	}
+
+	@ApiIgnore
+	@GetMapping("/api/v1/user/email-verified")
+	public String verifyUser(@Param("code") String code) {
+		if (userService.verify(code)) {
+			return "verify_success";
+		} else {
+			return "verify_fail";
+		}
 	}
 }

--- a/src/main/java/com/workat/api/user/controller/UserController.java
+++ b/src/main/java/com/workat/api/user/controller/UserController.java
@@ -86,6 +86,7 @@ public class UserController {
 	@ApiIgnore
 	@GetMapping("/api/v1/user/email-verified")
 	public String verifyUser(@Param("code") String code) {
+		// TODO: 메일 인증 후 redirect 페이지 여부에 따라 변경 가능
 		if (userService.verify(code)) {
 			return "verify_success";
 		} else {

--- a/src/main/java/com/workat/api/user/dto/request/EmailCertifyRequest.java
+++ b/src/main/java/com/workat/api/user/dto/request/EmailCertifyRequest.java
@@ -1,0 +1,19 @@
+package com.workat.api.user.dto.request;
+
+import static lombok.AccessLevel.*;
+
+import javax.validation.constraints.Email;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class EmailCertifyRequest {
+
+	@ApiModelProperty(name = "email", notes = "회사 메일", example = "\"workat.test.mail@gmail.com\"")
+	@Email
+	private String email;
+
+}

--- a/src/main/java/com/workat/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/workat/domain/user/entity/UserProfile.java
@@ -81,4 +81,8 @@ public class UserProfile extends BaseEntity {
 	public void updateImage(String imageUrl) {
 		this.imageUrl = imageUrl;
 	}
+
+	public void certifyCompanyMail() {
+		this.certified = true;
+	}
 }

--- a/src/main/java/com/workat/domain/user/entity/UserProfile.java
+++ b/src/main/java/com/workat/domain/user/entity/UserProfile.java
@@ -56,6 +56,7 @@ public class UserProfile extends BaseEntity {
 	@Column
 	private String story;
 
+	// TODO: 어떤 회사 인증했는지는 추후에 추가할 수 있음
 	@Column
 	private boolean certified;
 

--- a/src/main/java/com/workat/domain/user/entity/Users.java
+++ b/src/main/java/com/workat/domain/user/entity/Users.java
@@ -10,6 +10,8 @@ import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.Table;
 
+import net.bytebuddy.utility.RandomString;
+
 import com.workat.domain.BaseEntity;
 import com.workat.domain.auth.OauthType;
 import lombok.AccessLevel;
@@ -33,6 +35,9 @@ public class Users extends BaseEntity {
 	@Column(unique = true)
 	private Long oauthId;
 
+	@Column
+	private String verificationCode;
+
 	private Users(OauthType oauthType, Long oauthId) {
 		this.oauthType = oauthType;
 		this.oauthId = oauthId;
@@ -40,5 +45,13 @@ public class Users extends BaseEntity {
 
 	public static Users of(OauthType oauthType, Long oauthId) {
 		return new Users(oauthType, oauthId);
+	}
+
+	public void setVerificationCode() {
+		this.verificationCode = RandomString.make(64);
+	}
+
+	public void clearVerificationCode() {
+		this.verificationCode = null;
 	}
 }

--- a/src/main/java/com/workat/domain/user/repository/UsersRepository.java
+++ b/src/main/java/com/workat/domain/user/repository/UsersRepository.java
@@ -10,4 +10,6 @@ import com.workat.domain.user.entity.Users;
 public interface UsersRepository extends JpaRepository<Users, Long> {
 
 	Optional<Users> findByOauthTypeAndOauthId(OauthType oauthType, Long oauthId);
+
+	Optional<Users> findUsersByVerificationCode(String verificationCode);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,17 @@ spring:
     host: localhost
     port: 6379
     password: password
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: workat.test.mail@gmail.com
+    password: uzthqynsdmqsgofi
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 external:
   kakaoOauth:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
     host: smtp.gmail.com
     port: 587
     username: workat.test.mail@gmail.com
-    password: uzthqynsdmqsgofi
+    password: smtp_secret
     properties:
       mail:
         smtp:


### PR DESCRIPTION
#### AS-IS

#### TO-BE
- 메일 인증 api 추가

#### 리뷰시 중점 사항

#### 참조사항
- `/api/v1/user/verify`: 메일 인증 request api
  - `Users.verificationCode` 을 DB에 저장한다 (제한시간 없으므로)
  - 메일 내용에 `/api/v1/user/email-verified` 링크를 넣어 사용자에게 보낸다
- `/api/v1/user/email-verified?code=???&address=???`: 메일 내용 링크에 넣어서 사용자가 클릭하면 메일 인증 완료
  - 받은 code 값과 `Users.verificationCode` 비교 후 `UserProfile.certified` 업데이트