### PR TITLE
지도 기능, FE 피드백 반영

### DIFF
--- a/src/main/java/com/workat/api/map/controller/LocationController.java
+++ b/src/main/java/com/workat/api/map/controller/LocationController.java
@@ -9,8 +9,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.workat.api.map.dto.LocationDetailDto;
-import com.workat.api.map.dto.LocationPinDto;
 import com.workat.api.map.dto.response.LocationDetailResponse;
 import com.workat.api.map.dto.response.LocationResponse;
 import com.workat.api.map.service.LocationService;
@@ -42,7 +40,7 @@ public class LocationController {
 		@ApiImplicitParam(name = "radius", value = "반경", dataType = "Integer", example = "0", defaultValue = DEFAULT_RADIUS)
 	})
 	@ApiResponses(value = {
-		@ApiResponse(code = 200, message = "success", response = LocationDetailDto.class)
+		@ApiResponse(code = 200, message = "success")
 	})
 	@GetMapping("/api/v1/map/cafes")
 	public ResponseEntity<LocationResponse> getCafes(@UserValidation Users user,
@@ -61,7 +59,7 @@ public class LocationController {
 		@ApiImplicitParam(name = "radius", value = "반경", dataType = "Integer", example = "0", defaultValue = DEFAULT_RADIUS)
 	})
 	@ApiResponses(value = {
-		@ApiResponse(code = 200, message = "success", response = LocationPinDto.class)
+		@ApiResponse(code = 200, message = "success")
 	})
 	@GetMapping("/api/v1/map/cafes/pin")
 	public ResponseEntity<LocationResponse> getCafesPin(@UserValidation Users user,
@@ -90,7 +88,7 @@ public class LocationController {
 		@ApiImplicitParam(name = "radius", value = "반경", dataType = "Integer", example = "0", defaultValue = DEFAULT_RADIUS)
 	})
 	@ApiResponses(value = {
-		@ApiResponse(code = 200, message = "success", response = LocationDetailDto.class)
+		@ApiResponse(code = 200, message = "success")
 	})
 	@GetMapping("/api/v1/map/restaurants")
 	public ResponseEntity<LocationResponse> getRestaurants(@UserValidation Users user,
@@ -109,7 +107,7 @@ public class LocationController {
 		@ApiImplicitParam(name = "radius", value = "반경", dataType = "Integer", example = "0", defaultValue = DEFAULT_RADIUS)
 	})
 	@ApiResponses(value = {
-		@ApiResponse(code = 200, message = "success", response = LocationPinDto.class)
+		@ApiResponse(code = 200, message = "success")
 	})
 	@GetMapping("/api/v1/map/restaurants/pin")
 	public ResponseEntity<LocationResponse> getRestaurantsPin(@UserValidation Users user,
@@ -150,7 +148,8 @@ public class LocationController {
 	}
 
 	@GetMapping("/api/v1/map/restaurants/test")
-	public ResponseEntity<LocationResponse> getRestaurantsTest(@NotNull @RequestParam double longitude,
+	public ResponseEntity<LocationResponse> getRestaurantsTest(
+		@NotNull @RequestParam double longitude,
 		@NotNull @RequestParam double latitude,
 		@RequestParam(required = false, defaultValue = DEFAULT_RADIUS) int radius) {
 		LocationResponse response =
@@ -159,7 +158,8 @@ public class LocationController {
 	}
 
 	@GetMapping("/api/v1/map/restaurants/pin/test")
-	public ResponseEntity<LocationResponse> getRestaurantsPinTest(@NotNull @RequestParam double longitude,
+	public ResponseEntity<LocationResponse> getRestaurantsPinTest(
+		@NotNull @RequestParam double longitude,
 		@NotNull @RequestParam double latitude,
 		@RequestParam(required = false, defaultValue = DEFAULT_RADIUS) int radius) {
 		LocationResponse response =

--- a/src/main/java/com/workat/api/map/dto/LocationBriefDto.java
+++ b/src/main/java/com/workat/api/map/dto/LocationBriefDto.java
@@ -1,0 +1,34 @@
+package com.workat.api.map.dto;
+
+import com.workat.domain.map.entity.LocationCategory;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class LocationBriefDto implements LocationDto {
+
+	private long id;
+
+	private String placeId;
+
+	private double latitude;
+
+	private double longitude;
+
+	private LocationCategory category;
+
+	private String placeName;
+
+	private String roadAddressName;
+
+	private String thumbnailImageUrl;
+
+	private int reviewCount;
+}

--- a/src/main/java/com/workat/api/map/dto/LocationBriefDto.java
+++ b/src/main/java/com/workat/api/map/dto/LocationBriefDto.java
@@ -1,18 +1,18 @@
 package com.workat.api.map.dto;
 
+import java.util.List;
+
+import com.workat.api.review.dto.ReviewTypeDto;
 import com.workat.domain.map.entity.LocationCategory;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class LocationBriefDto implements LocationDto {
+public class LocationBriefDto extends LocationDto {
 
 	private long id;
 
@@ -31,4 +31,24 @@ public class LocationBriefDto implements LocationDto {
 	private String thumbnailImageUrl;
 
 	private int reviewCount;
+
+	private List<ReviewTypeDto> topReviews;
+
+	@Builder
+	public LocationBriefDto(long id, String placeId, double latitude, double longitude, LocationCategory category,
+		String placeName, String roadAddressName, String thumbnailImageUrl, int reviewCount,
+		List<ReviewTypeDto> topReviews) {
+		super(id, placeId, latitude, longitude);
+		this.id = id;
+		this.placeId = placeId;
+		this.latitude = latitude;
+		this.longitude = longitude;
+		this.category = category;
+		this.placeName = placeName;
+		this.roadAddressName = roadAddressName;
+		this.thumbnailImageUrl = thumbnailImageUrl;
+		this.reviewCount = reviewCount;
+		this.topReviews = topReviews;
+	}
+
 }

--- a/src/main/java/com/workat/api/map/dto/LocationBriefDto.java
+++ b/src/main/java/com/workat/api/map/dto/LocationBriefDto.java
@@ -14,14 +14,6 @@ import lombok.NoArgsConstructor;
 @Getter
 public class LocationBriefDto extends LocationDto {
 
-	private long id;
-
-	private String placeId;
-
-	private double latitude;
-
-	private double longitude;
-
 	private LocationCategory category;
 
 	private String placeName;
@@ -39,10 +31,7 @@ public class LocationBriefDto extends LocationDto {
 		String placeName, String roadAddressName, String thumbnailImageUrl, int reviewCount,
 		List<ReviewTypeDto> topReviews) {
 		super(id, placeId, latitude, longitude);
-		this.id = id;
-		this.placeId = placeId;
-		this.latitude = latitude;
-		this.longitude = longitude;
+		
 		this.category = category;
 		this.placeName = placeName;
 		this.roadAddressName = roadAddressName;

--- a/src/main/java/com/workat/api/map/dto/LocationDetailDto.java
+++ b/src/main/java/com/workat/api/map/dto/LocationDetailDto.java
@@ -3,12 +3,8 @@ package com.workat.api.map.dto;
 import com.workat.domain.map.entity.LocationCategory;
 
 import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,6 +21,8 @@ public class LocationDetailDto implements LocationDto {
 	private String placeId;
 
 	private String placeName;
+
+	private String roadAddressName;
 
 	private String placeUrl;
 

--- a/src/main/java/com/workat/api/map/dto/LocationDetailDto.java
+++ b/src/main/java/com/workat/api/map/dto/LocationDetailDto.java
@@ -3,36 +3,38 @@ package com.workat.api.map.dto;
 import com.workat.domain.map.entity.LocationCategory;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class LocationDetailDto implements LocationDto {
-
-	private long id;
+public class LocationDetailDto extends LocationDto {
 
 	private LocationCategory category;
-
-	private String placeId;
 
 	private String placeName;
 
 	private String roadAddressName;
 
-	private String placeUrl;
+	private String fullImageUrl;
 
 	private String phone;
 
-	private String fullImageUrl;
+	private String placeUrl;
 
-	private String thumbnailImageUrl;
+	@Builder
+	public LocationDetailDto(long id, String placeId, double latitude, double longitude,
+		LocationCategory category, String placeName, String roadAddressName, String fullImageUrl, String phone,
+		String placeUrl) {
+		super(id, placeId, latitude, longitude);
 
-	private double longitude;
-
-	private double latitude;
+		this.category = category;
+		this.placeName = placeName;
+		this.roadAddressName = roadAddressName;
+		this.fullImageUrl = fullImageUrl;
+		this.phone = phone;
+		this.placeUrl = placeUrl;
+	}
+	
 }

--- a/src/main/java/com/workat/api/map/dto/LocationDto.java
+++ b/src/main/java/com/workat/api/map/dto/LocationDto.java
@@ -1,4 +1,25 @@
 package com.workat.api.map.dto;
 
-public interface LocationDto {
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public abstract class LocationDto {
+
+	private long id;
+
+	private String placeId;
+
+	private double latitude;
+
+	private double longitude;
+
+	protected LocationDto(long id, String placeId, double latitude, double longitude) {
+		this.id = id;
+		this.placeId = placeId;
+		this.latitude = latitude;
+		this.longitude = longitude;
+	}
 }

--- a/src/main/java/com/workat/api/map/dto/LocationPinDto.java
+++ b/src/main/java/com/workat/api/map/dto/LocationPinDto.java
@@ -1,24 +1,18 @@
 package com.workat.api.map.dto;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class LocationPinDto implements LocationDto {
+public class LocationPinDto extends LocationDto {
 
-	private long id;
+	public LocationPinDto(long id, String placeId, double latitude, double longitude) {
+		super(id, placeId, latitude, longitude);
+	}
 
-	private String placeId;
-
-	private double longitude;
-
-	private double latitude;
-
-	public static LocationPinDto of(long id, String placeId, double longitude, double latitude) {
-		return new LocationPinDto(id, placeId, longitude, latitude);
+	static public LocationPinDto of(long id, String placeId, double latitude, double longitude) {
+		return new LocationPinDto(id, placeId, latitude, longitude);
 	}
 }

--- a/src/main/java/com/workat/api/map/dto/LocationPinDto.java
+++ b/src/main/java/com/workat/api/map/dto/LocationPinDto.java
@@ -12,7 +12,7 @@ public class LocationPinDto extends LocationDto {
 		super(id, placeId, latitude, longitude);
 	}
 
-	static public LocationPinDto of(long id, String placeId, double latitude, double longitude) {
+	public static LocationPinDto of(long id, String placeId, double latitude, double longitude) {
 		return new LocationPinDto(id, placeId, latitude, longitude);
 	}
 }

--- a/src/main/java/com/workat/api/map/dto/response/LocationDetailResponse.java
+++ b/src/main/java/com/workat/api/map/dto/response/LocationDetailResponse.java
@@ -1,7 +1,7 @@
 package com.workat.api.map.dto.response;
 
 import com.workat.api.map.dto.LocationDetailDto;
-import com.workat.api.review.dto.LocationReviewDto;
+import com.workat.api.review.dto.ReviewWithUserDto;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -16,9 +16,9 @@ public class LocationDetailResponse {
 	private LocationDetailDto locationDetail;
 
 	@ApiModelProperty(name = "locationReview", notes = "로케이션 리뷰")
-	private LocationReviewDto locationReview;
+	private ReviewWithUserDto locationReview;
 
-	public static LocationDetailResponse of(LocationDetailDto locationDetailDto, LocationReviewDto locationReviewDto) {
+	public static LocationDetailResponse of(LocationDetailDto locationDetailDto, ReviewWithUserDto locationReviewDto) {
 		final LocationDetailResponse locationDetailResponse = new LocationDetailResponse();
 
 		locationDetailResponse.locationDetail = locationDetailDto;

--- a/src/main/java/com/workat/api/map/dto/response/LocationResponse.java
+++ b/src/main/java/com/workat/api/map/dto/response/LocationResponse.java
@@ -14,9 +14,9 @@ import lombok.NoArgsConstructor;
 @Getter
 public class LocationResponse<T extends LocationDto> {
 
-	private List<T> data;
+	private List<T> locations;
 
-	public static <T extends LocationDto> LocationResponse of(List<T> list) {
-		return new LocationResponse<T>(list);
+	public static <T extends LocationDto> LocationResponse<T> of(List<T> list) {
+		return new LocationResponse<>(list);
 	}
 }

--- a/src/main/java/com/workat/api/map/service/LocationService.java
+++ b/src/main/java/com/workat/api/map/service/LocationService.java
@@ -15,9 +15,9 @@ import com.workat.api.map.dto.LocationDto;
 import com.workat.api.map.dto.LocationPinDto;
 import com.workat.api.map.dto.response.LocationDetailResponse;
 import com.workat.api.map.dto.response.LocationResponse;
-import com.workat.api.review.dto.LocationReviewDto;
 import com.workat.api.review.dto.ReviewDto;
 import com.workat.api.review.dto.ReviewTypeDto;
+import com.workat.api.review.dto.ReviewWithUserDto;
 import com.workat.api.review.service.ReviewService;
 import com.workat.common.exception.BadRequestException;
 import com.workat.common.exception.NotFoundException;
@@ -175,7 +175,7 @@ public class LocationService {
 			.placeUrl(location.getPlaceUrl())
 			.build();
 
-		final LocationReviewDto locationLocationReviewDto = reviewService.getLocationReviewsWithUser(
+		final ReviewWithUserDto locationLocationReviewDto = reviewService.getLocationReviewsWithUser(
 			locationId,
 			category,
 			userId);

--- a/src/main/java/com/workat/api/map/service/LocationService.java
+++ b/src/main/java/com/workat/api/map/service/LocationService.java
@@ -9,11 +9,15 @@ import java.util.stream.IntStream;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.workat.api.map.dto.LocationBriefDto;
 import com.workat.api.map.dto.LocationDetailDto;
+import com.workat.api.map.dto.LocationDto;
 import com.workat.api.map.dto.LocationPinDto;
 import com.workat.api.map.dto.response.LocationDetailResponse;
 import com.workat.api.map.dto.response.LocationResponse;
 import com.workat.api.review.dto.LocationReviewDto;
+import com.workat.api.review.dto.ReviewDto;
+import com.workat.api.review.dto.ReviewTypeDto;
 import com.workat.api.review.service.ReviewService;
 import com.workat.common.exception.BadRequestException;
 import com.workat.common.exception.NotFoundException;
@@ -35,6 +39,8 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class LocationService {
 
+	private static final int TOP_REVIEW_LENGTH = 3;
+
 	private final LocationHttpReceiver locationHttpReceiver;
 
 	private final ReviewService reviewService;
@@ -43,7 +49,9 @@ public class LocationService {
 
 	private final AreaRepository areaRepository;
 
-	public LocationResponse getLocations(boolean isPin, LocationCategory category, double longitude, double latitude,
+	// TODO: 2022/07/31 pin 과 brief 를 분리해보기
+	public LocationResponse<? extends LocationDto> getLocations(boolean isPin, LocationCategory category,
+		double longitude, double latitude,
 		int radius) {
 
 		if (category == null) {
@@ -67,25 +75,39 @@ public class LocationService {
 				.collect(Collectors.toList());
 
 			return LocationResponse.of(locationPinDtos);
-		} else {
-			List<LocationDetailDto> locationDetailDtos = locations.stream()
-				.map(location -> LocationDetailDto.builder()
-					.id(location.getId())
-					.category(location.getCategory())
-					.phone(location.getPhone())
-					.placeId(location.getPlaceId())
-					.placeUrl(location.getPlaceUrl())
-					.placeName(location.getPlaceName())
-					.longitude(location.getLongitude())
-					.latitude(location.getLatitude())
-					.build())
-				.collect(Collectors.toList());
-
-			return LocationResponse.of(locationDetailDtos);
 		}
+
+		List<LocationBriefDto> locationBriefs = locations.stream()
+			.map(location -> {
+				long locationId = location.getId();
+				List<ReviewDto> locationReviews = reviewService.getLocationReviews(locationId, category);
+
+				int reviewCount = locationReviews.size();
+				List<ReviewTypeDto> topReviews = locationReviews.stream()
+					.limit(TOP_REVIEW_LENGTH)
+					.map(ReviewDto::getReviewType)
+					.collect(Collectors.toList());
+
+				return LocationBriefDto.builder()
+					.id(locationId)
+					.placeId(location.getPlaceId())
+					.latitude(location.getLatitude())
+					.longitude(location.getLongitude())
+					.category(location.getCategory())
+					.placeName(location.getPlaceName())
+					.roadAddressName(location.getRoadAddressName())
+					// .thumbnailImageUrl(location.getThumbnailImageUrl()) // TODO: 파일 서버 구축되면 링크로 내려주기
+					.reviewCount(reviewCount)
+					.topReviews(topReviews)
+					.build();
+			})
+			.collect(Collectors.toList());
+
+		return LocationResponse.of(locationBriefs);
 	}
 
-	public LocationResponse getLocationsTest(boolean isPin, LocationCategory category, double longitude,
+	public LocationResponse<? extends LocationDto> getLocationsTest(boolean isPin, LocationCategory category,
+		double longitude,
 		double latitude, int radius) {
 
 		if (isPin) {
@@ -143,17 +165,20 @@ public class LocationService {
 
 		final LocationDetailDto locationDetailDto = LocationDetailDto.builder()
 			.id(location.getId())
-			.category(location.getCategory())
-			.phone(location.getPhone())
 			.placeId(location.getPlaceId())
-			.placeUrl(location.getPlaceUrl())
-			.placeName(location.getPlaceName())
-			.roadAddressName(location.getRoadAddressName())
 			.longitude(location.getLongitude())
 			.latitude(location.getLatitude())
+			.category(location.getCategory())
+			.placeName(location.getPlaceName())
+			.roadAddressName(location.getRoadAddressName())
+			.phone(location.getPhone())
+			.placeUrl(location.getPlaceUrl())
 			.build();
 
-		final LocationReviewDto locationLocationReviewDto = reviewService.getLocationReviews(locationId, userId);
+		final LocationReviewDto locationLocationReviewDto = reviewService.getLocationReviewsWithUser(
+			locationId,
+			category,
+			userId);
 
 		return LocationDetailResponse.of(
 			locationDetailDto,

--- a/src/main/java/com/workat/api/map/service/LocationService.java
+++ b/src/main/java/com/workat/api/map/service/LocationService.java
@@ -2,7 +2,6 @@ package com.workat.api.map.service;
 
 import java.io.File;
 import java.net.URL;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -149,11 +148,10 @@ public class LocationService {
 			.placeId(location.getPlaceId())
 			.placeUrl(location.getPlaceUrl())
 			.placeName(location.getPlaceName())
+			.roadAddressName(location.getRoadAddressName())
 			.longitude(location.getLongitude())
 			.latitude(location.getLatitude())
 			.build();
-
-		log.error("테스트에요");
 
 		final LocationReviewDto locationLocationReviewDto = reviewService.getLocationReviews(locationId, userId);
 

--- a/src/main/java/com/workat/api/review/dto/ReviewWithUserDto.java
+++ b/src/main/java/com/workat/api/review/dto/ReviewWithUserDto.java
@@ -17,12 +17,16 @@ public class ReviewWithUserDto {
 	@ApiModelProperty(name = "userReviewed", notes = "유저가 리뷰 남겼는지 여부")
 	private boolean userReviewed;
 
-	private ReviewWithUserDto(List<ReviewDto> reviewDtos, boolean userReviewed) {
+	@ApiModelProperty(name = "userCount", notes = "리뷰 남긴 유저 수")
+	private long userCount;
+
+	private ReviewWithUserDto(List<ReviewDto> reviewDtos, boolean userReviewed, long userCount) {
 		this.reviews = reviewDtos;
 		this.userReviewed = userReviewed;
+		this.userCount = userCount;
 	}
 
-	public static ReviewWithUserDto of(List<ReviewDto> reviewDtos, boolean userReviewed) {
-		return new ReviewWithUserDto(reviewDtos, userReviewed);
+	public static ReviewWithUserDto of(List<ReviewDto> reviewDtos, boolean userReviewed, long userCount) {
+		return new ReviewWithUserDto(reviewDtos, userReviewed, userCount);
 	}
 }

--- a/src/main/java/com/workat/api/review/dto/ReviewWithUserDto.java
+++ b/src/main/java/com/workat/api/review/dto/ReviewWithUserDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class LocationReviewDto {
+public class ReviewWithUserDto {
 
 	@ApiModelProperty(name = "reviews", notes = "리뷰들")
 	private List<ReviewDto> reviews;
@@ -17,12 +17,12 @@ public class LocationReviewDto {
 	@ApiModelProperty(name = "userReviewed", notes = "유저가 리뷰 남겼는지 여부")
 	private boolean userReviewed;
 
-	private LocationReviewDto(List<ReviewDto> reviewDtos, boolean userReviewed) {
+	private ReviewWithUserDto(List<ReviewDto> reviewDtos, boolean userReviewed) {
 		this.reviews = reviewDtos;
 		this.userReviewed = userReviewed;
 	}
 
-	public static LocationReviewDto of(List<ReviewDto> reviewDtos, boolean userReviewed) {
-		return new LocationReviewDto(reviewDtos, userReviewed);
+	public static ReviewWithUserDto of(List<ReviewDto> reviewDtos, boolean userReviewed) {
+		return new ReviewWithUserDto(reviewDtos, userReviewed);
 	}
 }

--- a/src/main/java/com/workat/api/review/service/ReviewService.java
+++ b/src/main/java/com/workat/api/review/service/ReviewService.java
@@ -44,11 +44,11 @@ public class ReviewService {
 	private final LocationRepository locationRepository;
 
 	@Transactional(readOnly = true)
-	public LocationReviewDto getLocationReviews(long locationId, long userId) {
+	public LocationReviewDto getLocationReviewsWithUser(long locationId, long userId) {
 
 		final List<CafeReview> cafeReviews = cafeReviewRepository.findAllByLocation_Id(locationId);
 
-		HashMap<BaseReviewType, Long> reviewCountMap = convertReviewCountMap(cafeReviews);
+		final HashMap<BaseReviewType, Long> reviewCountMap = convertReviewCountMap(cafeReviews);
 		final List<ReviewDto> sortedReviewDtos = getSortedReviewDtos(reviewCountMap);
 
 		final boolean userReviewed = checkUserReviewed(cafeReviews, userId);

--- a/src/main/java/com/workat/api/review/service/ReviewService.java
+++ b/src/main/java/com/workat/api/review/service/ReviewService.java
@@ -12,8 +12,8 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.workat.api.review.dto.LocationReviewDto;
 import com.workat.api.review.dto.ReviewDto;
+import com.workat.api.review.dto.ReviewWithUserDto;
 import com.workat.api.review.dto.request.ReviewRequest;
 import com.workat.common.exception.BadRequestException;
 import com.workat.common.exception.NotFoundException;
@@ -54,7 +54,7 @@ public class ReviewService {
 		return sortedReviewDtos;
 	}
 
-	public LocationReviewDto getLocationReviewsWithUser(long locationId, LocationCategory category, long userId) {
+	public ReviewWithUserDto getLocationReviewsWithUser(long locationId, LocationCategory category, long userId) {
 
 		final List<? extends BaseReview> reviews = getReviewsByCategory(locationId, category);
 
@@ -63,7 +63,7 @@ public class ReviewService {
 
 		final boolean userReviewed = checkUserReviewed(reviews, userId);
 
-		return LocationReviewDto.of(
+		return ReviewWithUserDto.of(
 			sortedReviewDtos,
 			userReviewed
 		);

--- a/src/main/java/com/workat/api/review/service/ReviewService.java
+++ b/src/main/java/com/workat/api/review/service/ReviewService.java
@@ -109,11 +109,8 @@ public class ReviewService {
 	}
 
 	private boolean checkUserReviewed(List<? extends BaseReview> reviews, long userId) {
-		final Optional<? extends BaseReview> reviewMatchedUser = reviews.stream()
-			.filter(review -> review.getUser().getId() == userId)
-			.findFirst();
-
-		return reviewMatchedUser.isPresent();
+		return reviews.stream()
+			.anyMatch(review -> review.getUser().getId() == userId);
 	}
 
 	@Transactional

--- a/src/main/java/com/workat/api/review/service/ReviewService.java
+++ b/src/main/java/com/workat/api/review/service/ReviewService.java
@@ -58,6 +58,7 @@ public class ReviewService {
 
 		final List<? extends BaseReview> reviews = getReviewsByCategory(locationId, category);
 
+		final long userCount = countReviewedUser(reviews);
 		final HashMap<BaseReviewType, Long> reviewCountMap = convertReviewCountMap(reviews);
 		final List<ReviewDto> sortedReviewDtos = getSortedReviewDtos(reviewCountMap);
 
@@ -65,7 +66,8 @@ public class ReviewService {
 
 		return ReviewWithUserDto.of(
 			sortedReviewDtos,
-			userReviewed
+			userReviewed,
+			userCount
 		);
 	}
 
@@ -77,6 +79,13 @@ public class ReviewService {
 		}
 
 		return restaurantReviewRepository.findAllByLocation_Id(locationId);
+	}
+
+	private <T extends BaseReview> long countReviewedUser(List<T> reviews) {
+		return reviews.stream()
+			.map(review -> review.getUser().getId())
+			.collect(toSet())
+			.size();
 	}
 
 	private <T extends BaseReview> HashMap<BaseReviewType, Long> convertReviewCountMap(List<T> reviews) {

--- a/src/main/java/com/workat/domain/review/entity/CafeReview.java
+++ b/src/main/java/com/workat/domain/review/entity/CafeReview.java
@@ -27,7 +27,7 @@ public class CafeReview extends BaseReview {
 		this.reviewType = reviewType;
 	}
 
-	static public CafeReview of(CafeReviewType reviewType, Location location, Users user) {
+	public static CafeReview of(CafeReviewType reviewType, Location location, Users user) {
 		return new CafeReview(reviewType, location, user);
 	}
 

--- a/src/main/java/com/workat/domain/review/entity/RestaurantReview.java
+++ b/src/main/java/com/workat/domain/review/entity/RestaurantReview.java
@@ -27,7 +27,7 @@ public class RestaurantReview extends BaseReview {
 		this.reviewType = reviewType;
 	}
 
-	static public RestaurantReview of(FoodReviewType reviewType, Location location, Users user) {
+	public static RestaurantReview of(FoodReviewType reviewType, Location location, Users user) {
 		return new RestaurantReview(reviewType, location, user);
 	}
 

--- a/src/test/java/com/workat/api/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/workat/api/review/service/ReviewServiceTest.java
@@ -225,6 +225,44 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 		);
 	}
 
+	@DisplayName("getLocationReviewsWithUser() 메소드는 리뷰를 남긴 유저의 수를 알려줘야 한다")
+	@Test
+	void getLocationReviewsWithUser_userCount() {
+		// given
+		final Location location = saveLocations(1, LocationCategory.CAFE).get(0);
+		final List<Users> users = saveUsers(3);
+
+		final Users user1 = users.get(0);
+		final Users user2 = users.get(1);
+		final Users user3 = users.get(2);
+
+		final CafeReview cafeReview1ByUser1 = CafeReview.of(CafeReviewType.PARKING, location, user1);
+		final CafeReview cafeReview2ByUser1 = CafeReview.of(CafeReviewType.PARKING, location, user1);
+		final CafeReview cafeReview3ByUser1 = CafeReview.of(CafeReviewType.PARKING, location, user1);
+		final CafeReview cafeReview4ByUser1 = CafeReview.of(CafeReviewType.PARKING, location, user1);
+		final CafeReview cafeReviewByUser2 = CafeReview.of(CafeReviewType.WIFI, location, user2);
+		final CafeReview cafeReviewByUser3 = CafeReview.of(CafeReviewType.WIFI, location, user3);
+
+		// user1 4개, user2, user3 1개씩 리뷰 저장
+		cafeReviewRepository.saveAll(Arrays.asList(
+			cafeReview1ByUser1,
+			cafeReview2ByUser1,
+			cafeReview3ByUser1,
+			cafeReview4ByUser1,
+			cafeReviewByUser2,
+			cafeReviewByUser3
+		));
+
+		// when
+		final long locationId = location.getId();
+
+		final ReviewWithUserDto locationReviews = reviewService.getLocationReviewsWithUser(locationId,
+			LocationCategory.CAFE, user1.getId());
+
+		// then
+		assertAll(() -> assertEquals(locationReviews.getUserCount(), 3));
+	}
+
 	@DisplayName("addCafeReview 메소드는 인자로 주어진 리뷰 타입 개수만큼 리뷰를 저장한다")
 	@Test
 	void addCafeReview_size() {

--- a/src/test/java/com/workat/api/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/workat/api/review/service/ReviewServiceTest.java
@@ -112,7 +112,7 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 			).collect(Collectors.toList());
 	}
 
-	@DisplayName("getLocationReviews() 메소드는 리뷰 개수, 타입이 저장한 것과 일치해야 한다")
+	@DisplayName("getLocationReviewsWithUser() 메소드는 리뷰 개수, 타입이 저장한 것과 일치해야 한다")
 	@Test
 	void reviewTypeSize() {
 		// given
@@ -132,7 +132,8 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 
 		// when
 		final long locationId = location.getId();
-		final List<ReviewDto> reviewDtos = reviewService.getLocationReviews(locationId, user1.getId()).getReviews();
+		final List<ReviewDto> reviewDtos = reviewService.getLocationReviewsWithUser(locationId, user1.getId())
+			.getReviews();
 
 		final Map<String, Long> reviewCountMap = reviewDtos.stream()
 			.collect(
@@ -147,9 +148,9 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 		);
 	}
 
-	@DisplayName("getLocationReviews() 메소드는 location 리뷰들을 count 역순으로 정렬해야 한다")
+	@DisplayName("getLocationReviewsWithUser() 메소드는 location 리뷰들을 count 역순으로 정렬해야 한다")
 	@Test
-	void getLocationReviews_sorted() {
+	void getLocationReviewsWithUser_sorted() {
 		// given
 		final Location location = saveLocations(1, LocationCategory.CAFE).get(0);
 		final List<Users> users = saveUsers(20);
@@ -177,7 +178,8 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 		// when
 		final long locationId = location.getId();
 		final Users user = users.get(0);
-		final List<ReviewDto> reviewDtos = reviewService.getLocationReviews(locationId, user.getId()).getReviews();
+		final List<ReviewDto> reviewDtos = reviewService.getLocationReviewsWithUser(locationId, user.getId())
+			.getReviews();
 
 		// then
 		assertEquals(reviewDtos.size(), 3); // PARKING, WIFI, VIEW
@@ -190,9 +192,9 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 		}
 	}
 
-	@DisplayName("getLocationReviews() 메소드는 user 가 해당 location 에 리뷰를 남겼는지 여부를 알려줘야 한다")
+	@DisplayName("getLocationReviewsWithUser() 메소드는 user 가 해당 location 에 리뷰를 남겼는지 여부를 알려줘야 한다")
 	@Test
-	void getLocationReviews_userReviewed() {
+	void getLocationReviewsWithUser_userReviewed() {
 		// given
 		final Location location = saveLocations(1, LocationCategory.CAFE).get(0);
 		final List<Users> users = saveUsers(3);
@@ -210,9 +212,9 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 		// when
 		final long locationId = location.getId();
 
-		final LocationReviewDto locationReviews1 = reviewService.getLocationReviews(locationId, user1.getId());
-		final LocationReviewDto locationReviews2 = reviewService.getLocationReviews(locationId, user2.getId());
-		final LocationReviewDto locationReviews3 = reviewService.getLocationReviews(locationId, user3.getId());
+		final LocationReviewDto locationReviews1 = reviewService.getLocationReviewsWithUser(locationId, user1.getId());
+		final LocationReviewDto locationReviews2 = reviewService.getLocationReviewsWithUser(locationId, user2.getId());
+		final LocationReviewDto locationReviews3 = reviewService.getLocationReviewsWithUser(locationId, user3.getId());
 
 		// then
 		assertAll(

--- a/src/test/java/com/workat/api/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/workat/api/review/service/ReviewServiceTest.java
@@ -40,7 +40,6 @@ import com.workat.domain.user.entity.Users;
 import com.workat.domain.user.job.DepartmentType;
 import com.workat.domain.user.job.DurationType;
 import com.workat.domain.user.repository.UserProfileRepository;
-import com.workat.domain.user.repository.UsersRepository;
 
 @DisplayName("ReviewService 테스트")
 @Import(DataJpaTestConfig.class)
@@ -58,9 +57,6 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 
 	@Autowired
 	private LocationRepository locationRepository;
-
-	@Autowired
-	private UsersRepository userRepository;
 
 	@Autowired
 	private UserProfileRepository userProfileRepository;
@@ -132,7 +128,8 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 
 		// when
 		final long locationId = location.getId();
-		final List<ReviewDto> reviewDtos = reviewService.getLocationReviewsWithUser(locationId, user1.getId())
+		final List<ReviewDto> reviewDtos = reviewService.getLocationReviewsWithUser(locationId, LocationCategory.CAFE,
+				user1.getId())
 			.getReviews();
 
 		final Map<String, Long> reviewCountMap = reviewDtos.stream()
@@ -178,7 +175,8 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 		// when
 		final long locationId = location.getId();
 		final Users user = users.get(0);
-		final List<ReviewDto> reviewDtos = reviewService.getLocationReviewsWithUser(locationId, user.getId())
+		final List<ReviewDto> reviewDtos = reviewService.getLocationReviewsWithUser(locationId, LocationCategory.CAFE,
+				user.getId())
 			.getReviews();
 
 		// then
@@ -212,9 +210,12 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 		// when
 		final long locationId = location.getId();
 
-		final LocationReviewDto locationReviews1 = reviewService.getLocationReviewsWithUser(locationId, user1.getId());
-		final LocationReviewDto locationReviews2 = reviewService.getLocationReviewsWithUser(locationId, user2.getId());
-		final LocationReviewDto locationReviews3 = reviewService.getLocationReviewsWithUser(locationId, user3.getId());
+		final LocationReviewDto locationReviews1 = reviewService.getLocationReviewsWithUser(locationId,
+			LocationCategory.CAFE, user1.getId());
+		final LocationReviewDto locationReviews2 = reviewService.getLocationReviewsWithUser(locationId,
+			LocationCategory.CAFE, user2.getId());
+		final LocationReviewDto locationReviews3 = reviewService.getLocationReviewsWithUser(locationId,
+			LocationCategory.CAFE, user3.getId());
 
 		// then
 		assertAll(

--- a/src/test/java/com/workat/api/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/workat/api/review/service/ReviewServiceTest.java
@@ -19,8 +19,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-import com.workat.api.review.dto.LocationReviewDto;
 import com.workat.api.review.dto.ReviewDto;
+import com.workat.api.review.dto.ReviewWithUserDto;
 import com.workat.api.review.dto.request.ReviewRequest;
 import com.workat.common.exception.BadRequestException;
 import com.workat.domain.auth.OauthType;
@@ -210,11 +210,11 @@ public class ReviewServiceTest extends MysqlContainerBaseTest {
 		// when
 		final long locationId = location.getId();
 
-		final LocationReviewDto locationReviews1 = reviewService.getLocationReviewsWithUser(locationId,
+		final ReviewWithUserDto locationReviews1 = reviewService.getLocationReviewsWithUser(locationId,
 			LocationCategory.CAFE, user1.getId());
-		final LocationReviewDto locationReviews2 = reviewService.getLocationReviewsWithUser(locationId,
+		final ReviewWithUserDto locationReviews2 = reviewService.getLocationReviewsWithUser(locationId,
 			LocationCategory.CAFE, user2.getId());
-		final LocationReviewDto locationReviews3 = reviewService.getLocationReviewsWithUser(locationId,
+		final ReviewWithUserDto locationReviews3 = reviewService.getLocationReviewsWithUser(locationId,
 			LocationCategory.CAFE, user3.getId());
 
 		// then


### PR DESCRIPTION
resolves #77 
#### AS-IS
* #77 

#### TO-BE
* fe 와 합의된 [api 문서](https://oil-force-e60.notion.site/API-2cf5b7af333747b6a711e1cf7220bc3e)에 맞춰 API response 포맷 변경
* 스웨거 포맷 변경

#### 리뷰시 중점 사항
* location 단건, 다건 조회가 차이가 생겨서 기존 LocationDetailDto 를 LocationDetailDto, LocationBriefDto 로 분리함 
* 추상 클래스 LocationDto 를 상속받도록 지도 dto 들을 수정함
* `getLocationReviews()` 는 유저가 리뷰를 남겼는지 체크하기 위한 `userReviewed` 필드가 있었음. `userReviewed` 필드 없이 리뷰만 필요한 경우가 생겼음. 그래서 네이밍을 기존 `getLocationReviews()` -> `getLocationReviewsWithUser()` 로 변경 후 리뷰만 주는 `getLocationReviews()` 를 추가
* 기존에 리뷰 줄 때 식당, 카페 레포지토리 나눠서 탐색해서 줘야 하는데 카페만 주고 있었음... 카테고리로 분기 타도록 수정
* 수정사항 테스트 코드에 반영

#### 참조사항
