### PR TITLE
채팅방 중복 생성 수정, 자기 자신과 채팅방 만들 수 없게 수정

### DIFF
--- a/src/main/java/com/workat/api/chat/service/ChatService.java
+++ b/src/main/java/com/workat/api/chat/service/ChatService.java
@@ -30,9 +30,7 @@ import com.workat.domain.user.repository.UserProfileRepository;
 import com.workat.domain.user.repository.UsersRepository;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RequiredArgsConstructor
 @Service
 public class ChatService {
@@ -45,7 +43,7 @@ public class ChatService {
 
 	@Transactional
 	public Long createChatRoom(Long ownerUserId, Long applyUserId) {
-		if (ownerUserId == applyUserId) {
+		if (ownerUserId.equals(applyUserId)) {
 			throw new BadRequestException("자기 자신과 채팅룸을 만들 수 없습니다.");
 		}
 
@@ -208,10 +206,6 @@ public class ChatService {
 		Long applicantId = applicant.getId();
 
 		List<ChatRoom> chatRooms = owner.getChatRooms();
-		log.info("test");
-		log.info(String.valueOf(chatRooms));
-		log.info(String.valueOf(chatRooms));
-		log.info(String.valueOf(chatRooms));
 
 		return owner.getChatRooms()
 			.stream()

--- a/src/main/java/com/workat/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/workat/domain/chat/entity/ChatRoom.java
@@ -50,13 +50,16 @@ public class ChatRoom extends BaseEntity {
 	public void assignUsers(Users owner, Users applicant) {
 		this.owner = owner;
 		this.applicant = applicant;
+
+		// 연관관계 매핑
+		owner.getChatRooms().add(this);
 	}
 
 	public void chattingConfirm(Long userId) {
 		if (userId.equals(owner.getId())) {
 			this.isStart = true;
 		} else {
-			throw new InvalidParameterException("this user(id : " + userId +") no authority, wrong value");
+			throw new InvalidParameterException("this user(id : " + userId + ") no authority, wrong value");
 		}
 	}
 

--- a/src/main/java/com/workat/domain/user/entity/Users.java
+++ b/src/main/java/com/workat/domain/user/entity/Users.java
@@ -1,5 +1,8 @@
 package com.workat.domain.user.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -8,12 +11,14 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import net.bytebuddy.utility.RandomString;
 
 import com.workat.domain.BaseEntity;
 import com.workat.domain.auth.OauthType;
+import com.workat.domain.chat.entity.ChatRoom;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -45,13 +50,18 @@ public class Users extends BaseEntity {
 	@Column
 	private boolean trackingOff;
 
-	private Users(OauthType oauthType, Long oauthId) {
+	@OneToMany(mappedBy = "owner")
+	private List<ChatRoom> chatRooms;
+
+	private Users(OauthType oauthType, Long oauthId, List<ChatRoom> chatRooms) {
 		this.oauthType = oauthType;
 		this.oauthId = oauthId;
+		this.chatRooms = chatRooms;
 	}
 
 	public static Users of(OauthType oauthType, Long oauthId) {
-		return new Users(oauthType, oauthId);
+
+		return new Users(oauthType, oauthId, new ArrayList<>());
 	}
 
 	public void setVerificationCode() {


### PR DESCRIPTION
resolves #122 

#### AS-IS

#### TO-BE
* 채팅방 중복 생성 수정
* 자기 자신과 채팅방 만들 수 없게 수정
* 테스트 코드 추가

#### 리뷰시 중점 사항
* ChatRooms 와 Users 간 양방향 연관관계 추가
* 중복 요청에 대한 에러는 400 보다 409 에러를 주면 좀 더 좋은 것 같네요~ 
  * [referenece](https://blog.outsider.ne.kr/1121)

#### 참조사항
